### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PanelTableView for iOS
+# PanelTableView for iOS
 Creates a UIViewController with multiple UITableView in a UIScrollView
 
 <img src="https://github.com/honcheng/PanelTableView/raw/master/blog-resources/plan.png"/>   


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
